### PR TITLE
fix POJO serialization

### DIFF
--- a/src/main/scala/io/mediachain/multihash/MultiHash.scala
+++ b/src/main/scala/io/mediachain/multihash/MultiHash.scala
@@ -21,6 +21,7 @@ object MultiHash {
   import scala.language.implicitConversions
 
   sealed abstract class HashType(val name: String, val index: Byte, val length: Byte)
+    extends Serializable
 
   case object sha1 extends HashType("SHA-1", 0x11, 20)
   case object sha256 extends HashType("SHA-256", 0x12, 32)

--- a/src/test/scala/io/mediachain/multihash/MultiHashSpec.scala
+++ b/src/test/scala/io/mediachain/multihash/MultiHashSpec.scala
@@ -1,11 +1,14 @@
 package io.mediachain.multihash
 
+
 import io.mediachain.BaseSpec
+
 
 object MultiHashSpec extends BaseSpec {
   def is =
   s2"""
     Calculates sha256-based multihash $sha256
+    Is POJO serializable: $serializableAsPojo
   """
 
   val str = "3A344E92C8F2EE8F54B8734F90328A946B0A4273DF8DEBA96A33D9C1EADFEFF82E7451663AF284DA025E2A12EFBAE0971D076C2D5AC30BD6A657601BD1FBC7AE"
@@ -20,5 +23,23 @@ object MultiHashSpec extends BaseSpec {
 
     multiHash.hashType must beEqualTo(MultiHash.sha256)
     multiHash.bytes must beEqualTo(expectedHashBytes)
+  }
+
+  def serializableAsPojo = {
+    import java.io.{ByteArrayInputStream, ByteArrayOutputStream, ObjectInputStream, ObjectOutputStream}
+    import scala.util.Try
+
+
+    val multiHash = MultiHash.hashWithSHA256(bytes)
+    val byteStream = new ByteArrayOutputStream
+    val out = new ObjectOutputStream(byteStream)
+    out.writeObject(multiHash)
+    out.close()
+    val in = new ObjectInputStream(new ByteArrayInputStream(byteStream.toByteArray))
+    val deserializedTry = Try(in.readObject().asInstanceOf[MultiHash])
+
+    deserializedTry must beSuccessfulTry { deserialized: MultiHash =>
+      deserialized == multiHash
+    }
   }
 }


### PR DESCRIPTION
This just makes the `HashType` abstract base class extend `Serializable`, which allows the `MultiHash` type to be serialized using POJO serialization.  Also adds a test case to verify that serialization to/from an `ObjectOutputStream` works.
