### PR TITLE
maven/sonatype publication settings

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1,5 +1,6 @@
 lazy val root = (project in file(".")).
   settings(
+    organization := "io.mediachain",
     name := "multihash",
     version := "0.1-SNAPSHOT",
     scalaVersion := "2.11.7",
@@ -7,5 +8,31 @@ lazy val root = (project in file(".")).
         "org.typelevel" %% "cats" % "0.4.1",
         "org.specs2" %% "specs2-core" % "3.7" % "test",
         "org.specs2" %% "specs2-junit" % "3.7" % "test"
-        )
+        ),
+
+    // Maven settings
+    publishMavenStyle := true,
+    publishArtifact in Test := false,
+    publishTo := {
+      val nexus = "https://oss.sonatype.org/"
+      if (isSnapshot.value)
+        Some("snapshots" at nexus + "content/repositories/snapshots")
+      else
+        Some("releases"  at nexus + "service/local/staging/deploy/maven2")
+    },
+    pomIncludeRepository := { _ => false },
+    licenses := Seq("MIT" -> url("https://raw.githubusercontent.com/mediachain/scala-multihash/master/LICENSE")),
+    homepage := Some(url("https://github.com/mediachain/scala-multihash")),
+    pomExtra :=
+      <scm>
+        <url>git@github.com/mediachain/scala-multihash.git</url>
+        <connection>scm:git:git@github.com/mediachain/scala-multihash.git</connection>
+      </scm>
+        <developers>
+          <developer>
+            <id>yusefnapora</id>
+            <name>Yusef Napora</name>
+            <url>http://napora.org</url>
+          </developer>
+        </developers>
   )


### PR DESCRIPTION
Adds the necessary metadata for publication to the Sonatype OSS repo.

To actually publish, you need to install the [sbt-gpg plugin](http://www.scala-sbt.org/sbt-pgp/index.html) locally (e.g. by adding `addSbtPlugin("com.jsuereth" % "sbt-pgp" % "1.0.1")` to `~/.sbt/0.13/plugins/gpg.sbt`).

It will probably also require some tedious gpg configuration to get it to use the correct key, etc.

You'll also need login credentials for the Sonatype repo, and I'll have to figure out how to add you to the group.   We can sort all that out privately 😄 
